### PR TITLE
Fixed infinite loop when the view appears

### DIFF
--- a/Sources/UIOnboarding/UIOnboardingViewController.swift
+++ b/Sources/UIOnboarding/UIOnboardingViewController.swift
@@ -35,6 +35,7 @@ public final class UIOnboardingViewController: UIViewController {
     }
     private var overlayIsHidden: Bool = false
     private var hasScrolledToBottom: Bool = false
+    private var needsUIRefresh: Bool = true
     
     public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return device.userInterfaceIdiom == .pad ? .all : .portrait
@@ -78,7 +79,11 @@ public final class UIOnboardingViewController: UIViewController {
     
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        updateUI()
+
+        if needsUIRefresh {
+            updateUI()
+            needsUIRefresh = false
+        }
     }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Sources/UIOnboarding/UIOnboardingViewController.swift
+++ b/Sources/UIOnboarding/UIOnboardingViewController.swift
@@ -85,6 +85,11 @@ public final class UIOnboardingViewController: UIViewController {
             needsUIRefresh = false
         }
     }
+
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        needsUIRefresh = true
+    }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         onboardingStackView.onboardingTitleLabel.font = .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? 80 : (UIScreenType.isiPhoneSE || UIScreenType.isiPhone6s ? 41 : 44), weight: .heavy)

--- a/Sources/UIOnboarding/UIOnboardingViewController.swift
+++ b/Sources/UIOnboarding/UIOnboardingViewController.swift
@@ -98,6 +98,8 @@ public final class UIOnboardingViewController: UIViewController {
         } else {
             onboardingTextView.font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? 15 : 13), maximumPointSize: traitCollection.horizontalSizeClass == .regular ? 21 : 19)
         }
+
+        needsUIRefresh = true
         onboardingTextView.layoutIfNeeded()
         continueButton.layoutIfNeeded()
     }


### PR DESCRIPTION
I've noticed a very high CPU usage when the view appears and found an infinite loop:

```mermaid
graph LR
id1("viewDidLayoutSubviews()")
id2("updateUI()")
id3("view.layoutIfNeeded()")

id1-->id2
id2-->id3
id3-->id1
```