### PR TITLE
Adopted trait registration API and fixed iOS 17 crash

### DIFF
--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/UIOnboardingViewController.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/UIOnboardingViewController.swift
@@ -53,11 +53,13 @@ final class UIOnboardingViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
         
-        if #available(iOS 17.0, *) {
-            registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
-                self.handleHorizontalSizeClassChange()
+        #if swift(>=5.9)
+            if #available(iOS 17.0, *) {
+                registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+                    self.handleHorizontalSizeClassChange()
+                }
             }
-        }
+        #endif
     }
     
     required init?(coder: NSCoder) {

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/UIOnboardingViewController.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/UIOnboardingViewController.swift
@@ -52,6 +52,12 @@ final class UIOnboardingViewController: UIViewController {
         self.screen = screen
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
+        
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+                self.handleHorizontalSizeClassChange()
+            }
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -91,6 +97,16 @@ final class UIOnboardingViewController: UIViewController {
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if #unavailable(iOS 17.0), traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
+            // iOS 17+ uses the trait registration API instead. (`registerForTraitChanges(_:handler:)`)
+            handleHorizontalSizeClassChange()
+        }
+    }
+    
+    private func handleHorizontalSizeClassChange() {
+        // Check if the view is visible and the properties are initialized.
+        guard viewIfLoaded?.window != nil else { return }
+
         onboardingStackView.onboardingTitleLabelStack.configureFont(traitCollection.horizontalSizeClass == .regular ? 80 : (UIScreenType.isiPhoneSE || UIScreenType.isiPhone6s ? 41 : 44))
 
         continueButtonHeight.constant = UIFontMetrics.default.scaledValue(for: traitCollection.horizontalSizeClass == .regular ? 50 : (UIScreenType.isiPhoneSE ? 48 : 52))

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingCell.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingCell.swift
@@ -56,6 +56,12 @@ final class UIOnboardingCell: UITableViewCell {
                 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+                self.handleHorizontalSizeClassChange()
+            }
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -113,6 +119,16 @@ final class UIOnboardingCell: UITableViewCell {
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if #unavailable(iOS 17.0), traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
+            // iOS 17+ uses the trait registration API instead. (`registerForTraitChanges(_:handler:)`)
+            handleHorizontalSizeClassChange()
+        }
+    }
+    
+    private func handleHorizontalSizeClassChange() {
+        // Check if the view is visible and the properties are initialized.
+        guard window != nil else { return }
+        
         configureFonts()
         
         stackBottom.constant = traitCollection.horizontalSizeClass == .regular ? -48 : -12

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingCell.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingCell.swift
@@ -57,11 +57,13 @@ final class UIOnboardingCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        if #available(iOS 17.0, *) {
-            registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
-                self.handleHorizontalSizeClassChange()
+        #if swift(>=5.9)
+            if #available(iOS 17.0, *) {
+                registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+                    self.handleHorizontalSizeClassChange()
+                }
             }
-        }
+        #endif
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/UIOnboarding/UIOnboardingViewController.swift
+++ b/Sources/UIOnboarding/UIOnboardingViewController.swift
@@ -52,6 +52,12 @@ public final class UIOnboardingViewController: UIViewController {
         self.screen = screen
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
+        
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+                self.handleHorizontalSizeClassChange()
+            }
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -91,6 +97,16 @@ public final class UIOnboardingViewController: UIViewController {
     }
     
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if #unavailable(iOS 17.0), traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
+            // iOS 17+ uses the trait registration API instead. (`registerForTraitChanges(_:handler:)`)
+            handleHorizontalSizeClassChange()
+        }
+    }
+    
+    private func handleHorizontalSizeClassChange() {
+        // Check if the view is visible and the properties are initialized.
+        guard viewIfLoaded?.window != nil else { return }
+
         onboardingStackView.onboardingTitleLabelStack.configureFont(traitCollection.horizontalSizeClass == .regular ? 80 : (UIScreenType.isiPhoneSE || UIScreenType.isiPhone6s ? 41 : 44))
 
         continueButtonHeight.constant = UIFontMetrics.default.scaledValue(for: traitCollection.horizontalSizeClass == .regular ? 50 : (UIScreenType.isiPhoneSE ? 48 : 52))

--- a/Sources/UIOnboarding/UIOnboardingViewController.swift
+++ b/Sources/UIOnboarding/UIOnboardingViewController.swift
@@ -53,11 +53,13 @@ public final class UIOnboardingViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
         
-        if #available(iOS 17.0, *) {
-            registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
-                self.handleHorizontalSizeClassChange()
+        #if swift(>=5.9)
+            if #available(iOS 17.0, *) {
+                registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+                    self.handleHorizontalSizeClassChange()
+                }
             }
-        }
+        #endif
     }
     
     required init?(coder: NSCoder) {

--- a/Sources/UIOnboarding/Views/UIOnboardingCell.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingCell.swift
@@ -56,6 +56,12 @@ final class UIOnboardingCell: UITableViewCell {
                 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+                self.handleHorizontalSizeClassChange()
+            }
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -113,6 +119,16 @@ final class UIOnboardingCell: UITableViewCell {
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if #unavailable(iOS 17.0), traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
+            // iOS 17+ uses the trait registration API instead. (`registerForTraitChanges(_:handler:)`)
+            handleHorizontalSizeClassChange()
+        }
+    }
+    
+    private func handleHorizontalSizeClassChange() {
+        // Check if the view is visible and the properties are initialized.
+        guard window != nil else { return }
+        
         configureFonts()
         
         stackBottom.constant = traitCollection.horizontalSizeClass == .regular ? -48 : -12

--- a/Sources/UIOnboarding/Views/UIOnboardingCell.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingCell.swift
@@ -57,11 +57,13 @@ final class UIOnboardingCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        if #available(iOS 17.0, *) {
-            registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
-                self.handleHorizontalSizeClassChange()
+        #if swift(>=5.9)
+            if #available(iOS 17.0, *) {
+                registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+                    self.handleHorizontalSizeClassChange()
+                }
             }
-        }
+        #endif
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
This PR fixes #15 

iOS 17 calls `traitCollectionDidChange(_:)` earlier in the lifecycle when the view properties are not yet initialized. This causes a crash which can be avoided by checking if the view is already visible.

This PR also adopts the new trait registration API in iOS 17: https://developer.apple.com/videos/play/wwdc2023-10057/?time=1196

**Note:** I've added another commit to restore compatibility with Xcode 14 because the symbols `UITraitHorizontalSizeClass` and `registerForTraitChanges` are not available in this version.