### PR TITLE
Allow different fonts on the same attributed string for titles

### DIFF
--- a/Sources/UIOnboarding/Views/UIOnboardingTitleLabel.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingTitleLabel.swift
@@ -38,6 +38,24 @@ final class UIOnboardingTitleLabel: UIIntrinsicLabel {
 }
 
 extension UIOnboardingTitleLabel {
+
+    func updateFontSize(_ fontSize: CGFloat) {
+        guard let attributedString = attributedText else { return }
+        let originalFont = font
+        let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
+        mutableAttributedString.enumerateAttributes(in: NSRange(location: 0,
+                                                                length: mutableAttributedString.length),
+                                                    options: []) { attributes, range, _ in
+            if let font = attributes[.font] as? UIFont {
+                let multiplier = font.pointSize / (originalFont?.pointSize ?? font.pointSize)
+                let newFont = font.withSize(fontSize * multiplier)
+                mutableAttributedString.addAttribute(.font, value: newFont, range: range)
+            }
+        }
+
+        self.attributedText = mutableAttributedString
+    }
+
     func setLineHeight(lineHeight: CGFloat) {
         let paragraphStyle: NSMutableParagraphStyle = .init()
         paragraphStyle.lineSpacing = 1.0

--- a/Sources/UIOnboarding/Views/UIOnboardingTitleLabelStack.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingTitleLabelStack.swift
@@ -42,8 +42,8 @@ extension UIOnboardingTitleLabelStack {
     }
     
     func configureFont(_ fontSize: CGFloat) {
-        firstTitleLineLabel.font = firstTitleLineLabel.font.withSize(fontSize)
-        secondTitleLineLabel.font = secondTitleLineLabel.font.withSize(fontSize)
+        firstTitleLineLabel.updateFontSize(fontSize)
+        secondTitleLineLabel.updateFontSize(fontSize)
     }
 }
 
@@ -60,9 +60,9 @@ private extension UIOnboardingTitleLabelStack {
         let secondTitleLineLabelFontSize: CGFloat = secondTitleLineLabel.calculateActualFontSize()
         
         if firstTitleLineLabelFontSize < secondTitleLineLabelFontSize {
-            secondTitleLineLabel.font = firstTitleLineLabel.font.withSize(firstTitleLineLabelFontSize)
+            secondTitleLineLabel.updateFontSize(firstTitleLineLabelFontSize)
         } else if secondTitleLineLabelFontSize < firstTitleLineLabelFontSize {
-            firstTitleLineLabel.font = secondTitleLineLabel.font.withSize(secondTitleLineLabelFontSize)
+            firstTitleLineLabel.updateFontSize(secondTitleLineLabelFontSize)
         }
     }
 }


### PR DESCRIPTION
Given the old implementation of setting a font point size (it was setting the font to the label, hence taking over any font defined in the attributed string, you could not mix fonts in the same title.

This PR fixes it so you can have different fonts, but also different font sizes!

![Simulator Screenshot - iPhone 16 Pro - 2024-11-29 at 14 48 24](https://github.com/user-attachments/assets/fddb9b61-ffc9-4f03-9203-2727709b7bb1)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-29 at 14 47 28](https://github.com/user-attachments/assets/0c2c1b59-d7b3-40e0-b8ec-219fc6bb72d9)
![Simulator Screenshot - iPhone 16 Pro - 2024-11-29 at 11 56 53](https://github.com/user-attachments/assets/16c0c6c8-5cc2-4b66-ae06-bb29d7f3a3fb)
