### PR TITLE
Added configuration option for footer icon color

### DIFF
--- a/Demo/UIOnboarding Demo SPM/UIOnboarding Demo SPM/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding Demo SPM/UIOnboarding Demo SPM/UIOnboardingHelper.swift
@@ -46,7 +46,7 @@ struct UIOnboardingHelper {
                      text: "Developed and designed for members of the Swiss Armed Forces.",
                      linkTitle: "Learn more...",
                      link: "https://www.lukmanascic.ch/portfolio/insignia",
-                     tint: .init(named: "camou") ?? .init(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0))
+                     linkColor: .init(named: "camou") ?? .init(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0))
     }
     
     static func setUpButton() -> UIOnboardingButtonConfiguration {

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Configuration/UIOnboardingTextViewConfiguration.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Configuration/UIOnboardingTextViewConfiguration.swift
@@ -13,19 +13,29 @@ struct UIOnboardingTextViewConfiguration {
     var linkTitle: String?
     var fontName: String
     var link: String?
-    var tint: UIColor?
+    var linkColor: UIColor?
+    var iconColor: UIColor?
+
+    @available(*, deprecated, renamed: "linkColor", message: "'tint' has been renamed to 'linkColor'. Use 'linkColor' instead.")
+    var tint: UIColor? {
+        get { linkColor }
+        set { linkColor = newValue }
+    }
 
     init(icon: UIImage? = nil,
-         text: String,
-         linkTitle: String? = nil,
-         fontName: String = "",
-         link: String? = nil,
-         tint: UIColor? = nil) {
+                text: String,
+                linkTitle: String? = nil,
+                fontName: String = "",
+                link: String? = nil,
+                linkColor: UIColor? = nil,
+                iconColor: UIColor? = nil)
+    {
         self.icon = icon
         self.text = text
         self.linkTitle = linkTitle
         self.fontName = fontName
         self.link = link
-        self.tint = tint
+        self.linkColor = linkColor
+        self.iconColor = iconColor
     }
 }

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/UIOnboardingViewController.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/UIOnboardingViewController.swift
@@ -223,7 +223,7 @@ private extension UIOnboardingViewController {
         
         if let icon = textViewConfiguration.icon {
             onboardingNoticeIcon = .init(image: icon.withRenderingMode(.alwaysTemplate))
-            onboardingNoticeIcon.tintColor = .secondaryLabel
+            onboardingNoticeIcon.tintColor = configuration.textViewConfiguration?.iconColor ?? .secondaryLabel
             onboardingNoticeIcon.contentMode = .scaleAspectFit
             onboardingNoticeIcon.translatesAutoresizingMaskIntoConstraints = false
             

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingTextView.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingTextView.swift
@@ -27,10 +27,10 @@ final class UIOnboardingTextView: UITextView {
         backgroundColor = .clear
         textContainerInset = .init(top: 0, left: 0, bottom: 30, right: 0)
         textColor = .secondaryLabel
-        if let tintColor = configuration.tint {
-            self.tintColor = tintColor
+        if let linkColor = configuration.linkColor {
+            tintColor = linkColor
         }
-        
+
         accessibilityHint = "Notice text and link"
         accessibilityTraits = .staticText
         accessibilityValue = "\(configuration.text) \(configuration.linkTitle ?? .init())"

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/UIOnboardingHelper.swift
@@ -45,7 +45,7 @@ struct UIOnboardingHelper {
               text: "Developed and designed for members of the Swiss Armed Forces.",
               linkTitle: "Learn more...",
               link: "https://www.lukmanascic.ch/portfolio/insignia",
-              tint: .init(named: "camou") ?? UIColor.init(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0))
+              linkColor: .init(named: "camou") ?? UIColor.init(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0))
     }
     
     static func setUpButton() -> UIOnboardingButtonConfiguration {

--- a/Demo/UIOnboarding SwiftUI/UIOnboarding SwiftUI/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding SwiftUI/UIOnboarding SwiftUI/UIOnboardingHelper.swift
@@ -46,7 +46,7 @@ struct UIOnboardingHelper {
                      text: "Developed and designed for members of the Swiss Armed Forces.",
                      linkTitle: "Learn more...",
                      link: "https://www.lukmanascic.ch/portfolio/insignia",
-                     tint: .init(named: "camou") ?? .init(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0))
+                     linkColor: .init(named: "camou") ?? .init(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0))
     }
     
     static func setUpButton() -> UIOnboardingButtonConfiguration {

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ struct UIOnboardingHelper {
                      text: "Developed and designed for members of the Swiss Armed Forces.",
                      linkTitle: "Learn more...",
                      link: "https://www.lukmanascic.ch/portfolio/insignia",
-                     tint: .init(named: "camou"))
+                     linkColor: .init(named: "camou"))
     }
 
     // Continuation Title

--- a/Sources/UIOnboarding/Configuration/UIOnboardingTextViewConfiguration.swift
+++ b/Sources/UIOnboarding/Configuration/UIOnboardingTextViewConfiguration.swift
@@ -13,19 +13,29 @@ public struct UIOnboardingTextViewConfiguration {
     public var linkTitle: String?
     public var fontName: String
     public var link: String?
-    public var tint: UIColor?
+    public var linkColor: UIColor?
+    public var iconColor: UIColor?
+
+    @available(*, deprecated, renamed: "linkColor", message: "'tint' has been renamed to 'linkColor'. Use 'linkColor' instead.")
+    public var tint: UIColor? {
+        get { linkColor }
+        set { linkColor = newValue }
+    }
 
     public init(icon: UIImage? = nil,
                 text: String,
                 linkTitle: String? = nil,
                 fontName: String = "",
                 link: String? = nil,
-                tint: UIColor? = nil) {
+                linkColor: UIColor? = nil,
+                iconColor: UIColor? = nil)
+    {
         self.icon = icon
         self.text = text
         self.linkTitle = linkTitle
         self.fontName = fontName
         self.link = link
-        self.tint = tint
+        self.linkColor = linkColor
+        self.iconColor = iconColor
     }
 }

--- a/Sources/UIOnboarding/UIOnboardingViewController.swift
+++ b/Sources/UIOnboarding/UIOnboardingViewController.swift
@@ -223,7 +223,7 @@ private extension UIOnboardingViewController {
         
         if let icon = textViewConfiguration.icon {
             onboardingNoticeIcon = .init(image: icon.withRenderingMode(.alwaysTemplate))
-            onboardingNoticeIcon.tintColor = .secondaryLabel
+            onboardingNoticeIcon.tintColor = configuration.textViewConfiguration?.iconColor ?? .secondaryLabel
             onboardingNoticeIcon.contentMode = .scaleAspectFit
             onboardingNoticeIcon.translatesAutoresizingMaskIntoConstraints = false
             

--- a/Sources/UIOnboarding/Views/UIOnboardingTextView.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingTextView.swift
@@ -27,8 +27,8 @@ final class UIOnboardingTextView: UITextView {
         backgroundColor = .clear
         textContainerInset = .init(top: 0, left: 0, bottom: 30, right: 0)
         textColor = .secondaryLabel
-        if let tintColor = configuration.tint {
-            self.tintColor = tintColor
+        if let linkColor = configuration.linkColor {
+            tintColor = linkColor
         }
         
         accessibilityHint = "Notice text and link"


### PR DESCRIPTION
This PR renames the `tint` property in `UIOnboardingTextViewConfiguration` to `linkColor` for clarity and adds a new `iconColor` property to allow configuration of the footer icon color. The deprecated `tint` property remains with a migration notice to provide a quick fix in Xcode. Documentation and usage examples have been updated to reflect these changes.