### PR TITLE
Added configuration option for footer font weight

### DIFF
--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Configuration/UIOnboardingTextViewConfiguration.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Configuration/UIOnboardingTextViewConfiguration.swift
@@ -12,6 +12,7 @@ struct UIOnboardingTextViewConfiguration {
     var text: String
     var linkTitle: String?
     var fontName: String
+    var fontWeight: UIFont.Weight?
     var link: String?
     var tint: UIColor?
 
@@ -19,12 +20,14 @@ struct UIOnboardingTextViewConfiguration {
          text: String,
          linkTitle: String? = nil,
          fontName: String = "",
+         fontWeight: UIFont.Weight? = nil,
          link: String? = nil,
          tint: UIColor? = nil) {
         self.icon = icon
         self.text = text
         self.linkTitle = linkTitle
         self.fontName = fontName
+        self.fontWeight = fontWeight
         self.link = link
         self.tint = tint
     }

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingTextView.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingTextView.swift
@@ -123,11 +123,12 @@ extension UIOnboardingTextView {
                 font = UIFontMetrics.default.scaledFont(for: customFont, maximumPointSize: traitCollection.horizontalSizeClass == .regular ? maximumBiggerFontSize : maximumDefaultFontSize)
             }
         } else {
+            let weight = configuration.fontWeight ?? .regular
             if #available(iOS 15.0, *) {
-                font =  UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? biggerFontSize : defaultFontSize))
+                font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? biggerFontSize : defaultFontSize, weight: weight))
                 maximumContentSizeCategory = .accessibilityMedium
             } else {
-                font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? biggerFontSize : defaultFontSize), maximumPointSize: traitCollection.horizontalSizeClass == .regular ? maximumBiggerFontSize : maximumDefaultFontSize)
+                font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? biggerFontSize : defaultFontSize, weight: weight), maximumPointSize: traitCollection.horizontalSizeClass == .regular ? maximumBiggerFontSize : maximumDefaultFontSize)
             }
         }
     }

--- a/Sources/UIOnboarding/Configuration/UIOnboardingTextViewConfiguration.swift
+++ b/Sources/UIOnboarding/Configuration/UIOnboardingTextViewConfiguration.swift
@@ -12,6 +12,7 @@ public struct UIOnboardingTextViewConfiguration {
     public var text: String
     public var linkTitle: String?
     public var fontName: String
+    public var fontWeight: UIFont.Weight?
     public var link: String?
     public var tint: UIColor?
 
@@ -19,12 +20,14 @@ public struct UIOnboardingTextViewConfiguration {
                 text: String,
                 linkTitle: String? = nil,
                 fontName: String = "",
+                fontWeight: UIFont.Weight? = nil,
                 link: String? = nil,
                 tint: UIColor? = nil) {
         self.icon = icon
         self.text = text
         self.linkTitle = linkTitle
         self.fontName = fontName
+        self.fontWeight = fontWeight
         self.link = link
         self.tint = tint
     }

--- a/Sources/UIOnboarding/Views/UIOnboardingTextView.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingTextView.swift
@@ -123,11 +123,12 @@ extension UIOnboardingTextView {
                 font = UIFontMetrics.default.scaledFont(for: customFont, maximumPointSize: traitCollection.horizontalSizeClass == .regular ? maximumBiggerFontSize : maximumDefaultFontSize)
             }
         } else {
+            let weight = configuration.fontWeight ?? .regular
             if #available(iOS 15.0, *) {
-                font =  UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? biggerFontSize : defaultFontSize))
+                font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? biggerFontSize : defaultFontSize, weight: weight))
                 maximumContentSizeCategory = .accessibilityMedium
             } else {
-                font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? biggerFontSize : defaultFontSize), maximumPointSize: traitCollection.horizontalSizeClass == .regular ? maximumBiggerFontSize : maximumDefaultFontSize)
+                font = UIFontMetrics.default.scaledFont(for: .systemFont(ofSize: traitCollection.horizontalSizeClass == .regular ? biggerFontSize : defaultFontSize, weight: weight), maximumPointSize: traitCollection.horizontalSizeClass == .regular ? maximumBiggerFontSize : maximumDefaultFontSize)
             }
         }
     }


### PR DESCRIPTION
This PR introduces a new `fontWeight` property to `UIOnboardingTextViewConfiguration`, allowing client apps to customize the font weight of the onboarding footer label (e.g., set it to `.semibold`). The property is optional and defaults to `.regular` if not specified, ensuring backward compatibility.