### PR TITLE
Fix layout issue with title font sizing in attributed strings

### DIFF
--- a/Sources/UIOnboarding/Views/UIOnboardingTitleLabel.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingTitleLabel.swift
@@ -41,15 +41,24 @@ extension UIOnboardingTitleLabel {
 
     func updateFontSize(_ fontSize: CGFloat) {
         guard let attributedString = attributedText else { return }
-        let originalFont = font
         let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
+
+        // Update the label's base font
+        let updatedBaseFont = font.withSize(fontSize)
+        self.font = updatedBaseFont
+
+        // Update fonts in the attributed string
         mutableAttributedString.enumerateAttributes(in: NSRange(location: 0,
                                                                 length: mutableAttributedString.length),
                                                     options: []) { attributes, range, _ in
-            if let font = attributes[.font] as? UIFont {
-                let multiplier = font.pointSize / (originalFont?.pointSize ?? font.pointSize)
-                let newFont = font.withSize(fontSize * multiplier)
+            if let existingFont = attributes[.font] as? UIFont {
+                // If font is already set in attributed string, preserve relative sizing
+                let multiplier = existingFont.pointSize / self.font.pointSize
+                let newFont = existingFont.withSize(fontSize * multiplier)
                 mutableAttributedString.addAttribute(.font, value: newFont, range: range)
+            } else {
+                // If no font is set, apply the base font
+                mutableAttributedString.addAttribute(.font, value: updatedBaseFont, range: range)
             }
         }
 


### PR DESCRIPTION
Fixes a critical bug where title labels (icon and "Welcome to" text) were rendering at approximately 1/4 screen size on iPad when using attributed strings without explicit font attributes.

## Problem

The `updateFontSize(_:)` method in `UIOnboardingTitleLabel` was calculating font size multipliers incorrectly when attributed strings didn't have font attributes pre-set. This caused the title labels to render at the wrong size on iPad.

### Root Cause

The original implementation (from PR #27) captured `originalFont = font` before updating the label's font property, then used this stale value to calculate multipliers. When attributed strings had no font attributes set, the multiplier calculation would use mismatched font sizes, resulting in incorrect rendering.

Additionally, the method only updated fonts that were already present in the attributed string, leaving ranges without font attributes unstyled.

## Solution

Updated `updateFontSize(_:)` to:

1. **Update the label's base font first** - Sets `self.font` to the target size before any calculations
2. **Handle attributed strings with font attributes** - Calculates multipliers using the updated base font, preserving PR #27's multi-font feature
3. **Handle attributed strings without font attributes** - Explicitly applies the base font to ranges that don't have a font set

## Screenshots

**Before**

<img width="744" height="1133" alt="IMG_0122" src="https://github.com/user-attachments/assets/61ef7730-8d39-4add-8b60-28f3075ce03a" />

<img width="744" height="1133" alt="IMG_0123" src="https://github.com/user-attachments/assets/e3d897a0-aac7-49d7-9bd0-cf83f2f56cf5" />

**After**

<img width="744" height="1133" alt="IMG_0124" src="https://github.com/user-attachments/assets/c091334c-d838-43da-b779-82b207db37c4" />

<img width="744" height="1133" alt="IMG_0125" src="https://github.com/user-attachments/assets/04655049-06bf-4a90-bfd2-becb196957a0" />