### PR TITLE
Add optional tagline to onboarding welcome screen

### DIFF
--- a/Demo/UIOnboarding Demo SPM/UIOnboarding Demo SPM/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding Demo SPM/UIOnboarding Demo SPM/UIOnboardingHelper.swift
@@ -27,6 +27,10 @@ struct UIOnboardingHelper {
         ])
     }
 
+    static func setUpTagline() -> String {
+        "Know Every Rank"
+    }
+
     static func setUpFeatures() -> Array<UIOnboardingFeature> {
         return .init([
             .init(icon: .init(named: "feature-1")!,
@@ -60,6 +64,7 @@ extension UIOnboardingViewConfiguration {
         return .init(appIcon: UIOnboardingHelper.setUpIcon(),
                      firstTitleLine: UIOnboardingHelper.setUpFirstTitleLine(),
                      secondTitleLine: UIOnboardingHelper.setUpSecondTitleLine(),
+                     tagline: UIOnboardingHelper.setUpTagline(),
                      features: UIOnboardingHelper.setUpFeatures(),
                      textViewConfiguration: UIOnboardingHelper.setUpNotice(),
                      buttonConfiguration: UIOnboardingHelper.setUpButton())

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Configuration/UIOnboardingViewConfiguration.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Configuration/UIOnboardingViewConfiguration.swift
@@ -11,14 +11,18 @@ struct UIOnboardingViewConfiguration {
     var appIcon: UIImage
     var firstTitleLine: NSMutableAttributedString
     var secondTitleLine: NSMutableAttributedString
+    var tagline: String? = nil
+    var taglineColor: UIColor? = nil
     var features: Array<UIOnboardingFeature>
     let featureStyle: UIOnboardingFeatureStyle
     var textViewConfiguration: UIOnboardingTextViewConfiguration? = nil
     var buttonConfiguration: UIOnboardingButtonConfiguration
-    
+
     init(appIcon: UIImage,
          firstTitleLine: NSMutableAttributedString,
          secondTitleLine: NSMutableAttributedString,
+         tagline: String? = nil,
+         taglineColor: UIColor? = nil,
          features: Array<UIOnboardingFeature>,
          featureStyle: UIOnboardingFeatureStyle = .init(),
          textViewConfiguration: UIOnboardingTextViewConfiguration? = nil,
@@ -26,6 +30,8 @@ struct UIOnboardingViewConfiguration {
         self.appIcon = appIcon
         self.firstTitleLine = firstTitleLine
         self.secondTitleLine = secondTitleLine
+        self.tagline = tagline
+        self.taglineColor = taglineColor
         self.features = features
         self.featureStyle = featureStyle
         self.textViewConfiguration = textViewConfiguration

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingStack.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingStack.swift
@@ -69,10 +69,31 @@ final class UIOnboardingStack: UIStackView {
         setCustomSpacing(26, after: onboardingIcon)
         
         addArrangedSubview(onboardingTitleLabelStack)
-        setCustomSpacing(traitCollection.horizontalSizeClass == .regular ? 40 : UIScreenType.setUpTitleSpacing(), after: onboardingTitleLabelStack)
         onboardingTitleLabelStack.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
         onboardingTitleLabelStack.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
-        
+
+        let titleSpacing: CGFloat = traitCollection.horizontalSizeClass == .regular ? 40 : UIScreenType.setUpTitleSpacing()
+        if let taglineText = configuration.tagline {
+            setCustomSpacing(14, after: onboardingTitleLabelStack)
+            let taglineLabel = UILabel()
+            taglineLabel.text = taglineText
+            var taglineFont = UIFont.systemFont(ofSize: 20, weight: .medium)
+            if let italicDescriptor = taglineFont.fontDescriptor.withSymbolicTraits(.traitItalic) {
+                taglineFont = UIFont(descriptor: italicDescriptor, size: 20)
+            }
+            taglineLabel.font = taglineFont
+            taglineLabel.textColor = configuration.taglineColor ?? .secondaryLabel
+            taglineLabel.numberOfLines = 0
+            taglineLabel.adjustsFontSizeToFitWidth = true
+            taglineLabel.minimumScaleFactor = 0.8
+            addArrangedSubview(taglineLabel)
+            taglineLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            taglineLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+            setCustomSpacing(titleSpacing, after: taglineLabel)
+        } else {
+            setCustomSpacing(titleSpacing, after: onboardingTitleLabelStack)
+        }
+
         addArrangedSubview(featuresList)
         featuresList.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
         featuresList.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/UIOnboardingHelper.swift
@@ -26,6 +26,10 @@ struct UIOnboardingHelper {
         ])
     }
     
+    static func setUpTagline() -> String {
+        "Know Every Rank"
+    }
+
     static func setUpFeatures() -> Array<UIOnboardingFeature> {
         .init([
             .init(icon: .init(named: "feature-1"),
@@ -59,6 +63,7 @@ extension UIOnboardingViewConfiguration {
         .init(appIcon: UIOnboardingHelper.setUpIcon(),
               firstTitleLine: UIOnboardingHelper.setUpFirstTitleLine(),
               secondTitleLine: UIOnboardingHelper.setUpSecondTitleLine(),
+              tagline: UIOnboardingHelper.setUpTagline(),
               features: UIOnboardingHelper.setUpFeatures(),
               textViewConfiguration: UIOnboardingHelper.setUpNotice(),
               buttonConfiguration: UIOnboardingHelper.setUpButton())

--- a/Demo/UIOnboarding SwiftUI/UIOnboarding SwiftUI/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding SwiftUI/UIOnboarding SwiftUI/UIOnboardingHelper.swift
@@ -27,6 +27,10 @@ struct UIOnboardingHelper {
         ])
     }
 
+    static func setUpTagline() -> String {
+        "Know Every Rank"
+    }
+
     static func setUpFeatures() -> Array<UIOnboardingFeature> {
         return .init([
             .init(icon: .init(named: "feature-1")!,
@@ -60,6 +64,7 @@ extension UIOnboardingViewConfiguration {
         return .init(appIcon: UIOnboardingHelper.setUpIcon(),
                      firstTitleLine: UIOnboardingHelper.setUpFirstTitleLine(),
                      secondTitleLine: UIOnboardingHelper.setUpSecondTitleLine(),
+                     tagline: UIOnboardingHelper.setUpTagline(),
                      features: UIOnboardingHelper.setUpFeatures(),
                      textViewConfiguration: UIOnboardingHelper.setUpNotice(),
                      buttonConfiguration: UIOnboardingHelper.setUpButton())

--- a/Sources/UIOnboarding/Configuration/UIOnboardingViewConfiguration.swift
+++ b/Sources/UIOnboarding/Configuration/UIOnboardingViewConfiguration.swift
@@ -11,14 +11,16 @@ public struct UIOnboardingViewConfiguration {
     public var appIcon: UIImage
     public var firstTitleLine: NSMutableAttributedString
     public var secondTitleLine: NSMutableAttributedString
+    public var tagline: String? = nil
     public var features: Array<UIOnboardingFeature>
     public let featureStyle: UIOnboardingFeatureStyle
     public var textViewConfiguration: UIOnboardingTextViewConfiguration? = nil
     public var buttonConfiguration: UIOnboardingButtonConfiguration
-    
+
     public init(appIcon: UIImage,
                 firstTitleLine: NSMutableAttributedString,
                 secondTitleLine: NSMutableAttributedString,
+                tagline: String? = nil,
                 features: Array<UIOnboardingFeature>,
                 featureStyle: UIOnboardingFeatureStyle = .init(),
                 textViewConfiguration: UIOnboardingTextViewConfiguration? = nil,
@@ -26,6 +28,7 @@ public struct UIOnboardingViewConfiguration {
         self.appIcon = appIcon
         self.firstTitleLine = firstTitleLine
         self.secondTitleLine = secondTitleLine
+        self.tagline = tagline
         self.features = features
         self.featureStyle = featureStyle
         self.textViewConfiguration = textViewConfiguration

--- a/Sources/UIOnboarding/Configuration/UIOnboardingViewConfiguration.swift
+++ b/Sources/UIOnboarding/Configuration/UIOnboardingViewConfiguration.swift
@@ -12,6 +12,7 @@ public struct UIOnboardingViewConfiguration {
     public var firstTitleLine: NSMutableAttributedString
     public var secondTitleLine: NSMutableAttributedString
     public var tagline: String? = nil
+    public var taglineColor: UIColor? = nil
     public var features: Array<UIOnboardingFeature>
     public let featureStyle: UIOnboardingFeatureStyle
     public var textViewConfiguration: UIOnboardingTextViewConfiguration? = nil
@@ -21,6 +22,7 @@ public struct UIOnboardingViewConfiguration {
                 firstTitleLine: NSMutableAttributedString,
                 secondTitleLine: NSMutableAttributedString,
                 tagline: String? = nil,
+                taglineColor: UIColor? = nil,
                 features: Array<UIOnboardingFeature>,
                 featureStyle: UIOnboardingFeatureStyle = .init(),
                 textViewConfiguration: UIOnboardingTextViewConfiguration? = nil,
@@ -29,6 +31,7 @@ public struct UIOnboardingViewConfiguration {
         self.firstTitleLine = firstTitleLine
         self.secondTitleLine = secondTitleLine
         self.tagline = tagline
+        self.taglineColor = taglineColor
         self.features = features
         self.featureStyle = featureStyle
         self.textViewConfiguration = textViewConfiguration

--- a/Sources/UIOnboarding/Views/UIOnboardingStack.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingStack.swift
@@ -69,10 +69,27 @@ final class UIOnboardingStack: UIStackView {
         setCustomSpacing(26, after: onboardingIcon)
         
         addArrangedSubview(onboardingTitleLabelStack)
-        setCustomSpacing(traitCollection.horizontalSizeClass == .regular ? 40 : UIScreenType.setUpTitleSpacing(), after: onboardingTitleLabelStack)
         onboardingTitleLabelStack.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
         onboardingTitleLabelStack.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
-        
+
+        let titleSpacing: CGFloat = traitCollection.horizontalSizeClass == .regular ? 40 : UIScreenType.setUpTitleSpacing()
+        if let taglineText = configuration.tagline {
+            setCustomSpacing(8, after: onboardingTitleLabelStack)
+            let taglineLabel = UILabel()
+            taglineLabel.text = taglineText
+            taglineLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+            taglineLabel.textColor = .secondaryLabel
+            taglineLabel.numberOfLines = 0
+            taglineLabel.adjustsFontSizeToFitWidth = true
+            taglineLabel.minimumScaleFactor = 0.8
+            addArrangedSubview(taglineLabel)
+            taglineLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            taglineLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+            setCustomSpacing(titleSpacing, after: taglineLabel)
+        } else {
+            setCustomSpacing(titleSpacing, after: onboardingTitleLabelStack)
+        }
+
         addArrangedSubview(featuresList)
         featuresList.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
         featuresList.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true

--- a/Sources/UIOnboarding/Views/UIOnboardingStack.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingStack.swift
@@ -74,11 +74,15 @@ final class UIOnboardingStack: UIStackView {
 
         let titleSpacing: CGFloat = traitCollection.horizontalSizeClass == .regular ? 40 : UIScreenType.setUpTitleSpacing()
         if let taglineText = configuration.tagline {
-            setCustomSpacing(8, after: onboardingTitleLabelStack)
+            setCustomSpacing(14, after: onboardingTitleLabelStack)
             let taglineLabel = UILabel()
             taglineLabel.text = taglineText
-            taglineLabel.font = .systemFont(ofSize: 17, weight: .semibold)
-            taglineLabel.textColor = .secondaryLabel
+            var taglineFont = UIFont.systemFont(ofSize: 20, weight: .medium)
+            if let italicDescriptor = taglineFont.fontDescriptor.withSymbolicTraits(.traitItalic) {
+                taglineFont = UIFont(descriptor: italicDescriptor, size: 20)
+            }
+            taglineLabel.font = taglineFont
+            taglineLabel.textColor = configuration.taglineColor ?? .secondaryLabel
             taglineLabel.numberOfLines = 0
             taglineLabel.adjustsFontSizeToFitWidth = true
             taglineLabel.minimumScaleFactor = 0.8


### PR DESCRIPTION
## Summary

- Adds an optional `tagline: String?` and `taglineColor: UIColor?` to `UIOnboardingViewConfiguration`, inserted between the title label stack and the features list
- When `tagline` is `nil`, the existing layout is preserved exactly (no visual regression)
- When set, renders an italic medium-weight label at 20pt in `.secondaryLabel` color (or a custom `taglineColor`) with 14pt spacing below the title and the existing title-to-features spacing below the tagline
- Updates all three demo apps (UIOnboarding Demo, UIOnboarding Demo SPM, UIOnboarding SwiftUI) with an example tagline `"Know Every Rank"` for the Insignia demo app
- Keeps the embedded copy of `UIOnboardingViewConfiguration` and `UIOnboardingStack` in UIOnboarding Demo in sync with the library source

## Test plan

- [ ] Build and run UIOnboarding Demo — tagline "Know Every Rank" appears between title and features list
- [ ] Build and run UIOnboarding Demo SPM — same
- [ ] Build and run UIOnboarding SwiftUI — same
- [ ] Verify that omitting `tagline` (or passing `nil`) produces no visual change vs. the previous layout

## Screenshots

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-19 at 15 42 08" src="https://github.com/user-attachments/assets/ec3f099e-ebfc-4453-a50d-4f95bedf6213" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-19 at 15 42 12" src="https://github.com/user-attachments/assets/3c66fb85-a6b2-4833-b3e0-451fb15fbf42" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)