### PR TITLE
Add isPremium badge support to UIOnboardingFeature

### DIFF
--- a/Demo/UIOnboarding Demo SPM/UIOnboarding Demo SPM/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding Demo SPM/UIOnboarding Demo SPM/UIOnboardingHelper.swift
@@ -36,6 +36,8 @@ struct UIOnboardingHelper {
                   title: "Enlist prepared",
                   description: "Practice with the app and pass the rank test on the first run."),
             .init(icon: .init(named: "feature-3")!,
+                  iconTint: .init(named: "camou") ?? UIColor.init(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0),
+                  isPremium: true,
                   title: "#teamarmee",
                   description: "Add name tags of your comrades or cadre. Insignia automatically keeps every name tag you create in iCloud.")
         ])

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Configuration/UIOnboardingFeature.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Configuration/UIOnboardingFeature.swift
@@ -10,12 +10,16 @@ import UIKit
 struct UIOnboardingFeature {
     var icon: UIImage!
     var iconTint: UIColor
+    var isPremium: Bool
+    var premiumBadgeTitle: String
     var title: String
     var description: String
-    
-    init(icon: UIImage!, iconTint: UIColor = .label, title: String, description: String) {
+
+    init(icon: UIImage!, iconTint: UIColor = .label, isPremium: Bool = false, premiumBadgeTitle: String = "Pro", title: String, description: String) {
         self.icon = icon
         self.iconTint = iconTint
+        self.isPremium = isPremium
+        self.premiumBadgeTitle = premiumBadgeTitle
         self.title = title
         self.description = description
     }

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingCell.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/Onboarding/Views/UIOnboardingCell.swift
@@ -109,15 +109,56 @@ final class UIOnboardingCell: UITableViewCell {
         set(feature)
     }
     
+    private var premiumBadge: UIView?
+
     private func set(_ feature: UIOnboardingFeature) {
+        premiumBadge?.removeFromSuperview()
+        premiumBadge = nil
+
         featureGlyph.image = feature.icon
         featureGlyph.tintColor = feature.iconTint
-                
+
         titleLabel.text = feature.title
         titleLabel.accessibilityLabel = feature.title
-        
+
         descriptionLabel.text = feature.description
         descriptionLabel.accessibilityLabel = feature.description
+
+        if feature.isPremium {
+            addPremiumBadge(tintColor: feature.iconTint, title: feature.premiumBadgeTitle)
+        }
+    }
+
+    private func addPremiumBadge(tintColor: UIColor, title: String) {
+
+        let label = UILabel()
+        label.text = title.uppercased()
+        label.font = .systemFont(ofSize: 8, weight: .heavy)
+        label.textColor = .white
+        label.textAlignment = .center
+
+        let badge = UIView()
+        badge.backgroundColor = tintColor
+        badge.layer.cornerRadius = 5
+        badge.clipsToBounds = true
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: badge.topAnchor, constant: 1),
+            label.bottomAnchor.constraint(equalTo: badge.bottomAnchor, constant: -1),
+            label.leadingAnchor.constraint(equalTo: badge.leadingAnchor, constant: 4),
+            label.trailingAnchor.constraint(equalTo: badge.trailingAnchor, constant: -4),
+        ])
+
+        contentView.addSubview(badge)
+        NSLayoutConstraint.activate([
+            badge.trailingAnchor.constraint(equalTo: featureGlyph.trailingAnchor, constant: 4),
+            badge.bottomAnchor.constraint(equalTo: featureGlyph.bottomAnchor, constant: 2),
+        ])
+
+        premiumBadge = badge
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Demo/UIOnboarding Demo/UIOnboarding Demo/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding Demo/UIOnboarding Demo/UIOnboardingHelper.swift
@@ -35,6 +35,8 @@ struct UIOnboardingHelper {
                   title: "Enlist prepared",
                   description: "Practice with the app and pass the rank test on the first run."),
             .init(icon: .init(named: "feature-3"),
+                  iconTint: UIColor(named: "camou") ?? UIColor(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0),
+                  isPremium: true,
                   title: "#teamarmee",
                   description: "Add name tags of your comrades or cadre. Insignia automatically keeps every name tag you create in iCloud.")
         ])

--- a/Demo/UIOnboarding SwiftUI/UIOnboarding SwiftUI/UIOnboardingHelper.swift
+++ b/Demo/UIOnboarding SwiftUI/UIOnboarding SwiftUI/UIOnboardingHelper.swift
@@ -36,6 +36,8 @@ struct UIOnboardingHelper {
                   title: "Enlist prepared",
                   description: "Practice with the app and pass the rank test on the first run."),
             .init(icon: .init(named: "feature-3")!,
+                  iconTint: .init(named: "camou") ?? UIColor.init(red: 0.654, green: 0.618, blue: 0.494, alpha: 1.0),
+                  isPremium: true,
                   title: "#teamarmee",
                   description: "Add name tags of your comrades or cadre. Insignia automatically keeps every name tag you create in iCloud.")
         ])

--- a/Sources/UIOnboarding/Configuration/UIOnboardingFeature.swift
+++ b/Sources/UIOnboarding/Configuration/UIOnboardingFeature.swift
@@ -10,12 +10,16 @@ import UIKit
 public struct UIOnboardingFeature {
     public var icon: UIImage
     public var iconTint: UIColor
+    public var isPremium: Bool
+    public var premiumBadgeTitle: String
     public var title: String
     public var description: String
-    
-    public init(icon: UIImage, iconTint: UIColor = .label, title: String, description: String) {
+
+    public init(icon: UIImage, iconTint: UIColor = .label, isPremium: Bool = false, premiumBadgeTitle: String = "Pro", title: String, description: String) {
         self.icon = icon
         self.iconTint = iconTint
+        self.isPremium = isPremium
+        self.premiumBadgeTitle = premiumBadgeTitle
         self.title = title
         self.description = description
     }

--- a/Sources/UIOnboarding/Views/UIOnboardingCell.swift
+++ b/Sources/UIOnboarding/Views/UIOnboardingCell.swift
@@ -109,15 +109,56 @@ final class UIOnboardingCell: UITableViewCell {
         set(feature)
     }
     
+    private var premiumBadge: UIView?
+
     private func set(_ feature: UIOnboardingFeature) {
+        premiumBadge?.removeFromSuperview()
+        premiumBadge = nil
+
         featureGlyph.image = feature.icon
         featureGlyph.tintColor = feature.iconTint
-                
+
         titleLabel.text = feature.title
         titleLabel.accessibilityLabel = feature.title
-        
+
         descriptionLabel.text = feature.description
         descriptionLabel.accessibilityLabel = feature.description
+
+        if feature.isPremium {
+            addPremiumBadge(tintColor: feature.iconTint, title: feature.premiumBadgeTitle)
+        }
+    }
+
+    private func addPremiumBadge(tintColor: UIColor, title: String) {
+
+        let label = UILabel()
+        label.text = title.uppercased()
+        label.font = .systemFont(ofSize: 8, weight: .heavy)
+        label.textColor = .white
+        label.textAlignment = .center
+
+        let badge = UIView()
+        badge.backgroundColor = tintColor
+        badge.layer.cornerRadius = 5
+        badge.clipsToBounds = true
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: badge.topAnchor, constant: 1),
+            label.bottomAnchor.constraint(equalTo: badge.bottomAnchor, constant: -1),
+            label.leadingAnchor.constraint(equalTo: badge.leadingAnchor, constant: 4),
+            label.trailingAnchor.constraint(equalTo: badge.trailingAnchor, constant: -4),
+        ])
+
+        contentView.addSubview(badge)
+        NSLayoutConstraint.activate([
+            badge.trailingAnchor.constraint(equalTo: featureGlyph.trailingAnchor, constant: 4),
+            badge.bottomAnchor.constraint(equalTo: featureGlyph.bottomAnchor, constant: 2),
+        ])
+
+        premiumBadge = badge
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
## Summary

This PR adds an optional premium badge overlay to feature rows in the onboarding screen.

### New properties on `UIOnboardingFeature`

- `isPremium: Bool` (default: `false`) — when `true`, renders a small capsule badge over the bottom-trailing corner of the feature icon
- `premiumBadgeTitle: String` (default: `"Pro"`) — the text shown inside the badge, always rendered uppercase

Both properties are additive with default values, so **existing code requires no changes**.

### Badge rendering

The badge is implemented directly in `UIOnboardingCell` as a `UIView` overlay using Auto Layout. It is anchored to the bottom-trailing corner of the feature glyph and correctly handles cell reuse (removed and re-evaluated on every `configure(feature:)` call).

### Demo apps updated

All three demo apps (`UIOnboarding Demo`, `UIOnboarding Demo SPM`, `UIOnboarding SwiftUI`) have been updated to showcase the badge on the `#teamarmee` feature using the app's camouflage tint color.

## Usage

```swift
UIOnboardingFeature(
    icon: UIImage(named: "feature-3")!,
    iconTint: .systemBlue,
    isPremium: true,
    premiumBadgeTitle: "Pro", // rendered as "PRO"
    title: "Cloud Sync",
    description: "Access your data on all your devices."
)
```

## Screenshots

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-25 at 11 33 52" src="https://github.com/user-attachments/assets/0d6c7fab-cc86-43ac-9add-e02f0d6cf307" />